### PR TITLE
feat: support transactional idempotency keys

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -19,6 +19,7 @@ export interface TransactionalEmailOptions {
 	transactionalId: string;
 	email: string;
 	dataVariables?: Record<string, unknown>;
+	idempotencyKey?: string;
 }
 
 export interface EventOptions {
@@ -440,6 +441,7 @@ export class Loops {
 					transactionalId: v.string(),
 					email: v.string(),
 					dataVariables: v.optional(v.any()),
+					idempotencyKey: v.optional(v.string()),
 				},
 				handler: async (ctx, args) => {
 					return await this.sendTransactional(ctx, args);

--- a/src/component/actions.ts
+++ b/src/component/actions.ts
@@ -187,10 +187,17 @@ export const sendTransactional = action({
 		transactionalId: v.string(),
 		email: v.string(),
 		dataVariables: v.optional(v.record(v.string(), v.any())),
+		idempotencyKey: v.optional(v.string()),
 	},
 	returns: successWithMessageIdResponseValidator,
 	handler: async (ctx, args) => {
 		const response = await loopsFetch(args.apiKey, "/transactional", {
+			headers:
+				args.idempotencyKey === undefined
+					? undefined
+					: {
+							"Idempotency-Key": args.idempotencyKey,
+						},
 			method: "POST",
 			json: {
 				transactionalId: args.transactionalId,
@@ -199,7 +206,7 @@ export const sendTransactional = action({
 			},
 		});
 
-		if (!response.ok) {
+		if (!(response.ok || response.status === 409)) {
 			const errorText = await response.text();
 			console.error(`Loops API error [${response.status}]:`, errorText);
 			await ctx.runMutation(internal.mutations.logEmailOperation, {
@@ -222,10 +229,9 @@ export const sendTransactional = action({
 			messageId: data.messageId,
 		});
 
-		return {
-			success: true,
-			messageId: data.messageId,
-		};
+		return data.messageId === undefined
+			? { success: true }
+			: { success: true, messageId: data.messageId };
 	},
 });
 

--- a/src/component/http.ts
+++ b/src/component/http.ts
@@ -153,6 +153,7 @@ http.route({
 				transactionalId: payload.transactionalId,
 				email: payload.email,
 				dataVariables: payload.dataVariables,
+				idempotencyKey: payload.idempotencyKey,
 			});
 			return jsonResponse(data);
 		} catch (error) {

--- a/src/component/validators.ts
+++ b/src/component/validators.ts
@@ -25,6 +25,7 @@ export const transactionalEmailValidator = v.object({
 	transactionalId: v.optional(v.string()),
 	email: v.string(),
 	dataVariables: v.optional(v.record(v.string(), v.any())),
+	idempotencyKey: v.optional(v.string()),
 });
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,7 @@ export interface TransactionalPayload {
 	transactionalId?: string;
 	email?: string;
 	dataVariables?: Record<string, unknown>;
+	idempotencyKey?: string;
 }
 
 export interface EventPayload {

--- a/test/component/lib.test.ts
+++ b/test/component/lib.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { api, internal } from "../../src/component/_generated/api";
-import { mockContactCreate, resetMocks, setupMockFetch } from "./mock-setup";
+import {
+	getLastLoopsRequest,
+	mockApiCall,
+	mockContactCreate,
+	resetMocks,
+	setupMockFetch,
+} from "./mock-setup";
 import { convexTest } from "./setup.test";
 
 describe("component lib", () => {
@@ -35,6 +41,40 @@ describe("component lib", () => {
 		// Verify contact was stored by checking count
 		const count = await t.query(api.queries.countContacts, {});
 		expect(count).toBeGreaterThanOrEqual(1);
+	});
+
+	test("sendTransactional forwards the idempotency key", async () => {
+		const t = convexTest();
+
+		await t.action(api.actions.sendTransactional, {
+			apiKey: "test-api-key",
+			email: "reader@example.com",
+			idempotencyKey: "newsletter-email:abc123",
+			transactionalId: "welcome-email",
+		});
+
+		const headers = new Headers(getLastLoopsRequest()?.init?.headers);
+		expect(headers.get("Idempotency-Key")).toBe("newsletter-email:abc123");
+	});
+
+	test("sendTransactional accepts an idempotent replay response", async () => {
+		const t = convexTest();
+		mockApiCall(
+			"https://app.loops.so/api/v1/transactional",
+			new Response(JSON.stringify({ message: "Already processed" }), {
+				headers: { "Content-Type": "application/json" },
+				status: 409,
+			}),
+		);
+
+		await expect(
+			t.action(api.actions.sendTransactional, {
+				apiKey: "test-api-key",
+				email: "reader@example.com",
+				idempotencyKey: "newsletter-email:abc123",
+				transactionalId: "welcome-email",
+			}),
+		).resolves.toMatchObject({ success: true });
 	});
 
 	test("updateContact updates existing contact", async () => {

--- a/test/component/mock-setup.ts
+++ b/test/component/mock-setup.ts
@@ -6,12 +6,18 @@ const LOOPS_API_BASE_URL = "https://app.loops.so/api/v1";
 
 // Store mock responses
 const mockResponses: Map<string, Response> = new Map();
+let lastLoopsRequest: { init?: RequestInit; url: string } | undefined;
 
 /**
  * Reset all mocks
  */
 export function resetMocks() {
 	mockResponses.clear();
+	lastLoopsRequest = undefined;
+}
+
+export function getLastLoopsRequest() {
+	return lastLoopsRequest;
 }
 
 /**
@@ -53,6 +59,7 @@ export function setupMockFetch() {
 			if (!url.startsWith(LOOPS_API_BASE_URL)) {
 				return originalFetch(input, init);
 			}
+			lastLoopsRequest = { init, url };
 
 			// Check if we have a custom mock response template
 			if (mockResponses.has(url)) {


### PR DESCRIPTION
## Summary

Adds optional Loops transactional-email idempotency support.

- forwards `idempotencyKey` through the client and component APIs;
- sends it as the Loops `Idempotency-Key` header;
- treats HTTP 409 as a previously accepted idempotent replay;
- omits `messageId` when the replay response does not provide one;
- adds component tests for header forwarding and replay behavior.

The caller remains responsible for durable work, retries, and scheduling. This change only exposes Loops’ provider-side idempotency behavior.

## Verification

- `bun run test`
- `bun run typecheck`
- `bun run build`
